### PR TITLE
Add OpenHaystack rotating-key device type + bulk import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 .direnv/
 .ruff_cache/
+
+# Additions for OpenHaystack fork
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Experimental custom integration to provide device tracker entities for FindMy Ne
 2. Enable the integration. You must add at least two 'devices': one Apple Account and one tracker device.
    1. When adding an account, you will need to specify an anisette server. You can use a public one, but it
       might start throwing errors after a while, so private servers are preferred. Google is your friend.
+   2. When adding a tracker, choose the type that matches your firmware:
+      - **Static** — single-key OpenHaystack tag (paste the private key)
+      - **Rolling** — real AirTag / FindMy accessory (upload the .plist)
+      - **OpenHaystack rotating** — firmware that rotates through a pre-generated
+        key list (upload the `devices.json` produced by OpenHaystack /
+        Macless-Haystack). All keys are polled in one Apple API call per
+        interval; the freshest report is surfaced on a single HA entity.
+        Uploading a file with multiple devices imports them in bulk.
 3. Enjoy!
 
 ## Increasing the update frequency

--- a/custom_components/findmy/config_flow.py
+++ b/custom_components/findmy/config_flow.py
@@ -39,6 +39,7 @@ from findmy import (
 )
 
 from .const import DOMAIN
+from .openhaystack import OpenHaystackAccessory, OpenHaystackAccessoryMapping
 
 if TYPE_CHECKING:
     from typing import Any
@@ -73,7 +74,7 @@ DATA_SCHEME_DEV_CHOOSE = vol.Schema(
     {
         "device_type": SelectSelector(
             SelectSelectorConfig(
-                options=["static", "rolling"],
+                options=["static", "rolling", "openhaystack"],
                 translation_key="device_type",
             ),
         ),
@@ -91,6 +92,13 @@ DATA_SCHEME_DEV_ROLLING = vol.Schema(
     {
         vol.Optional("name"): str,
         vol.Required("file"): FileSelector(FileSelectorConfig(accept=".json,.plist")),
+    },
+)
+
+DATA_SCHEME_DEV_OPENHAYSTACK = vol.Schema(
+    {
+        vol.Optional("name"): str,
+        vol.Required("file"): FileSelector(FileSelectorConfig(accept=".json")),
     },
 )
 
@@ -112,7 +120,7 @@ class MfaSubmitInput(TypedDict):
 
 
 class DeviceTypeInput(TypedDict):
-    device_type: Literal["static", "rolling"]
+    device_type: Literal["static", "rolling", "openhaystack"]
 
 
 class StaticDeviceInput(TypedDict):
@@ -121,6 +129,11 @@ class StaticDeviceInput(TypedDict):
 
 
 class RollingDeviceInput(TypedDict):
+    name: str
+    file: str
+
+
+class OpenHaystackDeviceInput(TypedDict):
     name: str
     file: str
 
@@ -140,7 +153,14 @@ class EntryDataRollingDevice(TypedDict):
     data: FindMyAccessoryMapping
 
 
-type DeviceEntryData = EntryDataStaticDevice | EntryDataRollingDevice
+class EntryDataOpenHaystackDevice(TypedDict):
+    type: Literal["device_openhaystack"]
+    data: OpenHaystackAccessoryMapping
+
+
+type DeviceEntryData = (
+    EntryDataStaticDevice | EntryDataRollingDevice | EntryDataOpenHaystackDevice
+)
 type EntryData = EntryDataAccount | DeviceEntryData
 
 
@@ -402,6 +422,11 @@ class InitialSetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="dev_rolling",
                 data_schema=DATA_SCHEME_DEV_ROLLING,
             )
+        if dev_type == "openhaystack":
+            return self.async_show_form(
+                step_id="dev_openhaystack",
+                data_schema=DATA_SCHEME_DEV_OPENHAYSTACK,
+            )
 
         return self.async_show_form(
             step_id="dev_choose",
@@ -480,6 +505,95 @@ class InitialSetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    async def async_step_dev_openhaystack(
+        self,
+        info: OpenHaystackDeviceInput | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        _LOGGER.debug("%s Step: dev_openhaystack - %s", self.__class__.__name__, info)
+
+        if not info:
+            return self.async_show_form(
+                step_id="dev_openhaystack",
+                data_schema=DATA_SCHEME_DEV_OPENHAYSTACK,
+                errors={"base": "invalid_dev"},
+            )
+
+        name_override = info.get("name", None)
+        file_id = info.get("file", "")
+
+        devices = await self.hass.async_add_executor_job(
+            _get_openhaystack_from_file, self.hass, file_id,
+        )
+        if not devices:
+            return self.async_show_form(
+                step_id="dev_openhaystack",
+                data_schema=DATA_SCHEME_DEV_OPENHAYSTACK,
+                errors={"base": "invalid_dev_key"},
+            )
+
+        _LOGGER.info(
+            "Importing %d OpenHaystack device(s) from devices.json",
+            len(devices),
+        )
+
+        # For each device after the first: schedule a headless background flow
+        # that lands in async_step_openhaystack_bulk and creates its own entry.
+        for extra in devices[1:]:
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": "openhaystack_bulk"},
+                    data=extra.to_json(),
+                ),
+            )
+
+        # Handle the first device in the current interactive flow.
+        device = devices[0]
+        if name_override:
+            device.name = name_override
+
+        data = EntryDataOpenHaystackDevice(
+            type="device_openhaystack",
+            data=device.to_json(),
+        )
+
+        return self.async_create_entry(
+            title=f"Device (OpenHaystack, {len(device.keypairs)} keys): {device.name}",
+            data=data,
+        )
+
+    async def async_step_openhaystack_bulk(
+        self,
+        info: OpenHaystackAccessoryMapping | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Headless import path used when the primary openhaystack flow's
+        devices.json contained more than one entry.  Called with the mapping
+        of a single OpenHaystackAccessory as the flow's initial data.
+        """
+        _LOGGER.debug(
+            "%s Step: openhaystack_bulk - %s",
+            self.__class__.__name__,
+            info,
+        )
+        if not info:
+            return self.async_abort(reason="unknown_error")
+
+        try:
+            device = OpenHaystackAccessory.from_json(info)
+        except (ValueError, KeyError, TypeError):
+            _LOGGER.exception("Bulk import failed to parse device data")
+            return self.async_abort(reason="unknown_error")
+
+        data = EntryDataOpenHaystackDevice(
+            type="device_openhaystack",
+            data=device.to_json(),
+        )
+
+        return self.async_create_entry(
+            title=f"Device (OpenHaystack, {len(device.keypairs)} keys): {device.name}",
+            data=data,
+        )
+
 
 def _get_device_from_file(hass: HomeAssistant, file_id: str) -> FindMyAccessory | None:
     """Load a FindMyAccessory from an uploaded file."""
@@ -496,3 +610,16 @@ def _get_device_from_file(hass: HomeAssistant, file_id: str) -> FindMyAccessory 
                 device = FindMyAccessory.from_json(f)
 
     return device
+
+
+def _get_openhaystack_from_file(
+    hass: HomeAssistant,
+    file_id: str,
+) -> list[OpenHaystackAccessory] | None:
+    """Load a list of OpenHaystackAccessory from an OpenHaystack devices.json file."""
+    with process_uploaded_file(hass, file_id) as f:
+        try:
+            return OpenHaystackAccessory.from_openhaystack_file(str(f))
+        except ValueError:
+            _LOGGER.exception("Failed to parse OpenHaystack devices.json")
+            return None

--- a/custom_components/findmy/coordinator.py
+++ b/custom_components/findmy/coordinator.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from findmy import FindMyAccessory, KeyPair, LocationReport, UnauthorizedError
 
+from .openhaystack import OpenHaystackAccessory
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -20,7 +22,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-FindMyDevice = KeyPair | FindMyAccessory
+FindMyDevice = KeyPair | FindMyAccessory | OpenHaystackAccessory
 type FindMyLocationData = dict[FindMyDevice, LocationReport | None]
 
 
@@ -73,18 +75,44 @@ class FindMyCoordinator(DataUpdateCoordinator[FindMyLocationData]):
             return {}
         _LOGGER.debug("Using lookup account: %s", account)
 
-        devices: list[FindMyDevice] = list(self.async_contexts())
-        _LOGGER.debug("Fetching reports for devices: %s", devices)
+        contexts: list[FindMyDevice] = list(self.async_contexts())
+
+        # Flatten OpenHaystackAccessory wrappers into their constituent KeyPairs
+        # so the FindMy library's fetch_location gets a flat list.  We remember
+        # which KeyPair belongs to which wrapper so we can aggregate results.
+        flat: list[KeyPair | FindMyAccessory] = []
+        owner_of: dict[KeyPair, OpenHaystackAccessory] = {}
+        for ctx in contexts:
+            if isinstance(ctx, OpenHaystackAccessory):
+                for kp in ctx.keypairs:
+                    flat.append(kp)
+                    owner_of[kp] = ctx
+            else:
+                flat.append(ctx)
+
+        _LOGGER.debug(
+            "Fetching reports for %d contexts (flattened to %d keys)",
+            len(contexts), len(flat),
+        )
         try:
-            device_reports = await account.fetch_location(devices)
+            device_reports = await account.fetch_location(flat)
         except UnauthorizedError as err:
             _LOGGER.exception("Unauthorized... :c")
             raise ConfigEntryAuthFailed from err
 
         data: FindMyLocationData = (self.data or {}).copy()
         for device, report in device_reports.items():
-            _LOGGER.debug("Got reports for device: %s - %s", device, report)
-            if not isinstance(device, FindMyDevice):
+            _LOGGER.debug("Got report for %s: %s", device, report)
+
+            # Route the report back to an OpenHaystack wrapper if applicable
+            if isinstance(device, KeyPair) and device in owner_of:
+                wrapper = owner_of[device]
+                existing = data.get(wrapper)
+                if report and (existing is None or report.timestamp > existing.timestamp):
+                    data[wrapper] = report
+                continue
+
+            if not isinstance(device, (KeyPair, FindMyAccessory)):
                 _LOGGER.warning("Device not supported yet: %s", device)
                 continue
 

--- a/custom_components/findmy/device_tracker.py
+++ b/custom_components/findmy/device_tracker.py
@@ -18,6 +18,7 @@ from findmy import FindMyAccessory, KeyPair
 from .config_flow import DeviceEntryData
 from .const import DOMAIN
 from .coordinator import FindMyCoordinator, FindMyDevice
+from .openhaystack import OpenHaystackAccessory
 from .storage import RuntimeStorage
 
 if TYPE_CHECKING:
@@ -94,6 +95,9 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
         if isinstance(self._device, KeyPair):
             return self._device.hashed_adv_key_b64
 
+        if isinstance(self._device, OpenHaystackAccessory):
+            return self._device.identifier
+
         assert isinstance(self._device, FindMyAccessory)
 
         identifier = self._device.identifier
@@ -137,6 +141,9 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
     def mac_address(self) -> str | None:
         if isinstance(self._device, KeyPair):
             return self._device.mac_address
+        if isinstance(self._device, OpenHaystackAccessory):
+            # The tag rotates its MAC; report the leader key's MAC as a placeholder.
+            return self._device.keypairs[0].mac_address
         return None
 
     @cached_property
@@ -164,6 +171,9 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
             attrs["alignment_index"] = self._device._alignment_index  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
             attrs["alignment_date"] = self._device._alignment_date  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 
+        if isinstance(self._device, OpenHaystackAccessory):
+            attrs["key_count"] = len(self._device.keypairs)
+
         return attrs
 
     def _update_entry(self) -> None:
@@ -175,6 +185,11 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
         if isinstance(self._device, KeyPair):
             data: DeviceEntryData = {
                 "type": "device_static",
+                "data": self._device.to_json(),
+            }
+        elif isinstance(self._device, OpenHaystackAccessory):
+            data = {
+                "type": "device_openhaystack",
                 "data": self._device.to_json(),
             }
         elif isinstance(self._device, FindMyAccessory):  # pyright: ignore[reportUnnecessaryIsInstance]

--- a/custom_components/findmy/openhaystack.py
+++ b/custom_components/findmy/openhaystack.py
@@ -1,0 +1,111 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+
+"""OpenHaystack rotating-key accessory - wraps N KeyPairs as a single trackable device."""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, TypedDict
+
+from findmy import KeyPair
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from findmy import LocationReport
+
+
+class OpenHaystackAccessoryMapping(TypedDict):
+    """Serialized shape for HASS config entry storage."""
+
+    name: str
+    private_keys: list[str]
+
+
+class OpenHaystackAccessory:
+    """A single logical tag whose firmware rotates through a fixed set of pre-generated keys.
+
+    The findmy.py library treats each key as an independent `KeyPair`. We collect
+    them under one name, ask Apple for reports on every key, and surface the
+    freshest report as the tag's current position.
+
+    JSON import formats supported:
+      - `devices.json` from OpenHaystack / Macless-Haystack / this repo's
+        `generate_keys.py`. Each device entry has `privateKey` (leader) plus
+        `additionalKeys` (list of base64 privkeys).
+    """
+
+    def __init__(self, name: str, keypairs: list[KeyPair]) -> None:
+        if not keypairs:
+            msg = "OpenHaystackAccessory needs at least one KeyPair"
+            raise ValueError(msg)
+        self.name: str = name
+        self._keypairs: list[KeyPair] = keypairs
+        for kp in self._keypairs:
+            kp.name = name  # so aggregated reports still surface a friendly name
+
+    @property
+    def keypairs(self) -> list[KeyPair]:
+        return self._keypairs
+
+    @property
+    def identifier(self) -> str:
+        """Stable unique ID = hash of the leader adv key."""
+        return self._keypairs[0].hashed_adv_key_b64
+
+    def pick_latest(self, reports: dict[KeyPair, LocationReport | None]) -> LocationReport | None:
+        """Return the most-recent report across any of our keys, or None."""
+        best: LocationReport | None = None
+        for kp in self._keypairs:
+            report = reports.get(kp)
+            if report is None:
+                continue
+            if best is None or report.timestamp > best.timestamp:
+                best = report
+        return best
+
+    def to_json(self) -> OpenHaystackAccessoryMapping:
+        return {
+            "name": self.name,
+            "private_keys": [kp.private_key_b64 for kp in self._keypairs],
+        }
+
+    @classmethod
+    def from_json(cls, data: OpenHaystackAccessoryMapping) -> OpenHaystackAccessory:
+        keypairs = [KeyPair.from_b64(k) for k in data["private_keys"]]
+        return cls(data.get("name", "Unknown"), keypairs)
+
+    @classmethod
+    def from_openhaystack_file(cls, file_path: str) -> list[OpenHaystackAccessory]:
+        """Load one or more accessories from an OpenHaystack `devices.json`."""
+        with open(file_path, encoding="utf-8") as f:
+            raw: Any = json.load(f)  # noqa: ANN401
+        return cls.from_openhaystack_data(raw)
+
+    @classmethod
+    def from_openhaystack_data(cls, raw: Any) -> list[OpenHaystackAccessory]:  # noqa: ANN401
+        """Parse the already-decoded devices.json structure."""
+        if isinstance(raw, dict):
+            raw = [raw]
+        if not isinstance(raw, list):
+            msg = "Unexpected devices.json shape (expected list or dict)"
+            raise ValueError(msg)
+
+        result: list[OpenHaystackAccessory] = []
+        for i, item in enumerate(raw):
+            if not isinstance(item, dict):
+                msg = f"Entry {i} is not a dict"
+                raise ValueError(msg)
+            name = item.get("name") or f"Device {i + 1}"
+            leader = item.get("privateKey")
+            if not leader:
+                msg = f"Entry {i} has no 'privateKey'"
+                raise ValueError(msg)
+            extras = item.get("additionalKeys") or []
+            if not isinstance(extras, list):
+                msg = f"Entry {i} 'additionalKeys' is not a list"
+                raise ValueError(msg)
+
+            all_keys: list[str] = [leader, *extras]
+            keypairs = [KeyPair.from_b64(k) for k in all_keys]
+            result.append(cls(name, keypairs))
+        return result

--- a/custom_components/findmy/storage.py
+++ b/custom_components/findmy/storage.py
@@ -7,6 +7,7 @@ from findmy import AsyncAppleAccount, FindMyAccessory, KeyPair
 
 from .const import DOMAIN
 from .coordinator import FindMyCoordinator, FindMyDevice
+from .openhaystack import OpenHaystackAccessory
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -97,6 +98,17 @@ class RuntimeStorage:
 
             self._entries[entry.entry_id] = accessory
             return accessory
+
+        if data["type"] == "device_openhaystack":
+            oh = OpenHaystackAccessory.from_json(data["data"])
+
+            _LOGGER.debug(
+                "Storing entry %s as OpenHaystack tag: %s (%d keys)",
+                entry.entry_id, oh.name, len(oh.keypairs),
+            )
+
+            self._entries[entry.entry_id] = oh
+            return oh
 
         msg = f"Could not match entry {data['type']} with StorageItem!"
         raise ValueError(msg)

--- a/custom_components/findmy/translations/en.json
+++ b/custom_components/findmy/translations/en.json
@@ -56,6 +56,14 @@
           "name": "Name",
           "file": "Device keys"
         }
+      },
+      "dev_openhaystack": {
+        "title": "Add an OpenHaystack rotating-key device",
+        "description": "Upload the devices.json produced by OpenHaystack / Macless-Haystack. A file with multiple devices is imported in bulk (one HA config entry per device).",
+        "data": {
+          "name": "Name (optional override for the first device)",
+          "file": "OpenHaystack devices.json"
+        }
       }
     },
     "error": {
@@ -73,8 +81,9 @@
   "selector": {
     "device_type": {
       "options": {
-        "static": "Static-key tag (OpenHaystack)",
-        "rolling": "Rolling-key tag (AirTag)"
+        "static": "Static-key tag (single OpenHaystack key)",
+        "rolling": "Rolling-key tag (AirTag .plist)",
+        "openhaystack": "OpenHaystack rotating tag (devices.json)"
       }
     }
   }


### PR DESCRIPTION
New device type 'openhaystack' that accepts the devices.json format produced by OpenHaystack / Macless-Haystack (one privateKey leader plus an additionalKeys[] array) and tracks a firmware iterating a pre-generated key set as a single Home Assistant entity.

Motivation: firmwares with e.g. MAX_KEYS=250 rotate through 250 different BLE addresses over a 3h cycle. Configuring one as a Static device only polls the first key, so ~99.6% of the tag's advertisements go unnoticed by HA. The new type registers all N keys under one entity, fetches all of them in a single Apple API call per interval, and surfaces the freshest report.

Implementation summary:

- openhaystack.py: OpenHaystackAccessory wraps a list[KeyPair] with a stable identifier (leader adv-key hash) and knows how to parse the devices.json shape. from_openhaystack_file() returns a list so a single upload can carry multiple accessories.
- config_flow.py: new dev_openhaystack step handles the interactive upload for the first accessory, then schedules headless openhaystack_bulk flows for the remaining entries so one file yields N config entries.
- coordinator.py: the FindMyDevice union gains OpenHaystackAccessory. In _async_update_data, wrapped accessories are flattened to their KeyPairs before fetch_location and aggregated back with a most-recent-wins policy.
- device_tracker.py: unique_id / mac_address / _update_entry gain the new type; key_count is exposed as an attribute.
- storage.py: adds the device_openhaystack case.
- translations: new step description and device_type option.
- README: type table row.