### PR TITLE
Add sensor + binary_sensor platforms for lat/lon history + battery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 .direnv/
 .ruff_cache/
+
+# Additions for OpenHaystack fork
+.DS_Store

--- a/custom_components/findmy/__init__.py
+++ b/custom_components/findmy/__init__.py
@@ -12,7 +12,11 @@ from .storage import RuntimeStorage
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.DEVICE_TRACKER]
+PLATFORMS = [
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+]
 
 
 async def async_setup(hass: HomeAssistant, _config: ConfigEntry) -> bool:

--- a/custom_components/findmy/_entity.py
+++ b/custom_components/findmy/_entity.py
@@ -1,0 +1,114 @@
+"""Shared helpers for FindMy entities (device_tracker + sensor + binary_sensor).
+
+Keeps device grouping / unique-ID logic in one place so all platforms
+attach to the same HASS "device" and remain in sync when the coordinator
+updates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from findmy import FindMyAccessory, KeyPair
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from findmy import LocationReport
+
+    from .coordinator import FindMyCoordinator, FindMyDevice
+
+
+def device_unique_id(device: FindMyDevice) -> str:
+    """Stable identifier used both for the device registry and for the primary
+    device_tracker's unique_id. All companion entities derive from this."""
+    if isinstance(device, KeyPair):
+        return device.hashed_adv_key_b64
+
+    assert isinstance(device, FindMyAccessory)
+    identifier = device.identifier
+    if identifier is None:
+        msg = "Device has no identifier"
+        raise ValueError(msg)
+    return identifier
+
+
+def device_name(device: FindMyDevice) -> str:
+    return device.name or "Unknown"
+
+
+def build_device_info(device: FindMyDevice) -> DeviceInfo:
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_unique_id(device))},
+        name=device_name(device),
+    )
+
+
+def latest_report(
+    coordinator: FindMyCoordinator,
+    device: FindMyDevice,
+) -> LocationReport | None:
+    if coordinator.data is None:
+        return None
+    return coordinator.data.get(device)
+
+
+# --- Battery bits (Apple Find My payload byte 6, bits 6-7) ----------------
+# Encoded by the OpenHaystack firmware convention:
+#   0b00 = OK        (>80 %)
+#   0b01 = medium    (50-80 %)
+#   0b10 = low       (30-50 %)
+#   0b11 = critical  (<30 %)
+# Real AirTags encode the same 2-bit region with the same semantics.
+
+BATTERY_LABELS = {
+    0b00: "ok",
+    0b01: "medium",
+    0b10: "low",
+    0b11: "critical",
+}
+
+# Rough percentage centres for each level. Not accurate; the tag only
+# transmits 2 bits. Use these for the sensor value or leave the raw label.
+BATTERY_PERCENTS = {
+    0b00: 90,
+    0b01: 65,
+    0b10: 40,
+    0b11: 15,
+}
+
+# CR2032 voltage curve mapped to the 4 levels. Also a rough estimate.
+BATTERY_VOLTAGES_MV = {
+    0b00: 3000,
+    0b01: 2800,
+    0b10: 2600,
+    0b11: 2400,
+}
+
+
+def battery_bits(status: int | None) -> int | None:
+    if status is None:
+        return None
+    return (status >> 6) & 0b11
+
+
+def battery_label(status: int | None) -> str | None:
+    bits = battery_bits(status)
+    return BATTERY_LABELS.get(bits) if bits is not None else None
+
+
+def battery_percent(status: int | None) -> int | None:
+    bits = battery_bits(status)
+    return BATTERY_PERCENTS.get(bits) if bits is not None else None
+
+
+def battery_voltage_mv(status: int | None) -> int | None:
+    bits = battery_bits(status)
+    return BATTERY_VOLTAGES_MV.get(bits) if bits is not None else None
+
+
+def status_counter(status: int | None) -> int | None:
+    if status is None:
+        return None
+    return status & 0b00111111

--- a/custom_components/findmy/binary_sensor.py
+++ b/custom_components/findmy/binary_sensor.py
@@ -1,0 +1,106 @@
+"""FindMy binary_sensor platform: battery-low flag for automations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, final, override
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ._entity import (
+    battery_bits,
+    build_device_info,
+    device_unique_id,
+    latest_report,
+)
+from .coordinator import FindMyCoordinator, FindMyDevice
+from .storage import RuntimeStorage
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceInfo
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> bool:
+    _LOGGER.debug("Setting up binary_sensor entry: %s", entry.entry_id)
+
+    item = RuntimeStorage.get(hass).get_entry(entry)
+    if not isinstance(item, FindMyDevice):
+        msg = "Cannot setup binary_sensor entities for non-device!"
+        raise ConfigEntryNotReady(msg)
+
+    storage = RuntimeStorage.get(hass)
+    async_add_entities(
+        (FindMyBatteryLowBinarySensor(storage.coordinator, item, entry.entry_id),),
+    )
+
+    return True
+
+
+@final
+class FindMyBatteryLowBinarySensor(  # pyright: ignore[reportUninitializedInstanceVariable]
+    CoordinatorEntity[FindMyCoordinator],
+    BinarySensorEntity,
+):
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_name = "Battery low"
+    _attr_device_class = BinarySensorDeviceClass.BATTERY
+
+    def __init__(
+        self,
+        coordinator: FindMyCoordinator,
+        device: FindMyDevice,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator, context=device)
+        self._coordinator: FindMyCoordinator = coordinator
+        self._device: FindMyDevice = device
+        self._entry_id: str = entry_id
+        self._cached: bool | None = None
+
+    @property
+    @override
+    def unique_id(self) -> str:  # pyright: ignore[reportIncompatibleVariableOverride]
+        return f"{device_unique_id(self._device)}_battery_low"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:  # pyright: ignore[reportIncompatibleVariableOverride]
+        return build_device_info(self._device)
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        self._cached = self._compute()
+        self.async_write_ha_state()
+
+    def _compute(self) -> bool | None:
+        report = latest_report(self._coordinator, self._device)
+        bits = battery_bits(report.status if report else None)
+        if bits is None:
+            return None
+        # low = 0b10, critical = 0b11 => bit 1 set
+        return bits >= 0b10
+
+    @property
+    @override
+    def is_on(self) -> bool | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached
+        if val is None:
+            val = self._compute()
+        return val

--- a/custom_components/findmy/device_tracker.py
+++ b/custom_components/findmy/device_tracker.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from findmy import FindMyAccessory, KeyPair
 
+from ._entity import battery_percent as _battery_percent
 from .config_flow import DeviceEntryData
 from .const import DOMAIN
 from .coordinator import FindMyCoordinator, FindMyDevice
@@ -132,6 +133,15 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
         if self._last_location is None:
             return None
         return self._last_location.status
+
+    @property
+    def battery_level(self) -> int | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        """Rough battery % decoded from the status byte (0/50/70/90).
+
+        Drives the battery icon on HA's map card.  Companion sensor entities
+        (from the sensor platform) surface the same value plus a text label
+        and an opt-in mV estimate."""
+        return _battery_percent(self.status)
 
     @property
     def mac_address(self) -> str | None:

--- a/custom_components/findmy/sensor.py
+++ b/custom_components/findmy/sensor.py
@@ -1,0 +1,262 @@
+"""FindMy sensor platform: lat/lon (recorded to HASS history) + battery
+level / percent / voltage sensors derived from the Apple Find My status
+byte the tag advertises."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, final, override
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from ._entity import (
+    battery_label,
+    battery_percent,
+    battery_voltage_mv,
+    build_device_info,
+    device_unique_id,
+    latest_report,
+    status_counter,
+)
+from .coordinator import FindMyCoordinator, FindMyDevice
+from .storage import RuntimeStorage
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceInfo
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> bool:
+    _LOGGER.debug("Setting up sensor entry: %s", entry.entry_id)
+
+    item = RuntimeStorage.get(hass).get_entry(entry)
+    if not isinstance(item, FindMyDevice):
+        msg = "Cannot setup sensor entities for non-device!"
+        raise ConfigEntryNotReady(msg)
+
+    storage = RuntimeStorage.get(hass)
+    async_add_entities(
+        (
+            FindMyLatitudeSensor(storage.coordinator, item, entry.entry_id),
+            FindMyLongitudeSensor(storage.coordinator, item, entry.entry_id),
+            FindMyPositionSensor(storage.coordinator, item, entry.entry_id),
+            FindMyBatteryLevelSensor(storage.coordinator, item, entry.entry_id),
+            FindMyBatteryPercentSensor(storage.coordinator, item, entry.entry_id),
+            FindMyBatteryVoltageSensor(storage.coordinator, item, entry.entry_id),
+            FindMyStatusCounterSensor(storage.coordinator, item, entry.entry_id),
+        ),
+    )
+
+    return True
+
+
+class _FindMyBaseSensor(  # pyright: ignore[reportUninitializedInstanceVariable]
+    CoordinatorEntity[FindMyCoordinator],
+    SensorEntity,
+):
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    _suffix: str = ""
+
+    def __init__(
+        self,
+        coordinator: FindMyCoordinator,
+        device: FindMyDevice,
+        entry_id: str,
+    ) -> None:
+        super().__init__(coordinator, context=device)
+        self._coordinator: FindMyCoordinator = coordinator
+        self._device: FindMyDevice = device
+        self._entry_id: str = entry_id
+        self._cached_value: object | None = None
+
+    @property
+    @override
+    def unique_id(self) -> str:  # pyright: ignore[reportIncompatibleVariableOverride]
+        return f"{device_unique_id(self._device)}_{self._suffix}"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:  # pyright: ignore[reportIncompatibleVariableOverride]
+        return build_device_info(self._device)
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        self._cached_value = self._compute_value()
+        self.async_write_ha_state()
+
+    def _compute_value(self) -> object | None:
+        return None
+
+
+@final
+class FindMyLatitudeSensor(_FindMyBaseSensor):
+    _attr_name = "Latitude"
+    _attr_native_unit_of_measurement = "°"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 6
+    _suffix = "latitude"
+
+    @override
+    def _compute_value(self) -> float | None:
+        report = latest_report(self._coordinator, self._device)
+        return report.latitude if report else None
+
+    @property
+    @override
+    def native_value(self) -> float | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyLongitudeSensor(_FindMyBaseSensor):
+    _attr_name = "Longitude"
+    _attr_native_unit_of_measurement = "°"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 6
+    _suffix = "longitude"
+
+    @override
+    def _compute_value(self) -> float | None:
+        report = latest_report(self._coordinator, self._device)
+        return report.longitude if report else None
+
+    @property
+    @override
+    def native_value(self) -> float | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyPositionSensor(_FindMyBaseSensor):
+    """Convenience sensor combining lat + lon in a single 'lat,lon' string.
+    Not graphable, but handy for template concatenation, notifications and
+    passing to external map tools."""
+
+    _attr_name = "Position"
+    _suffix = "position"
+
+    @override
+    def _compute_value(self) -> str | None:
+        report = latest_report(self._coordinator, self._device)
+        if report is None:
+            return None
+        return f"{report.latitude:.6f},{report.longitude:.6f}"
+
+    @property
+    @override
+    def native_value(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyBatteryLevelSensor(_FindMyBaseSensor):
+    _attr_name = "Battery level"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = ["ok", "medium", "low", "critical"]
+    _suffix = "battery_level"
+
+    @override
+    def _compute_value(self) -> str | None:
+        report = latest_report(self._coordinator, self._device)
+        return battery_label(report.status if report else None)
+
+    @property
+    @override
+    def native_value(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyBatteryPercentSensor(_FindMyBaseSensor):
+    _attr_name = "Battery"
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = "%"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _suffix = "battery_percent"
+
+    @override
+    def _compute_value(self) -> int | None:
+        report = latest_report(self._coordinator, self._device)
+        return battery_percent(report.status if report else None)
+
+    @property
+    @override
+    def native_value(self) -> int | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyBatteryVoltageSensor(_FindMyBaseSensor):
+    _attr_name = "Battery voltage"
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_native_unit_of_measurement = "mV"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = False  # estimate only, opt-in
+    _suffix = "battery_voltage"
+
+    @override
+    def _compute_value(self) -> int | None:
+        report = latest_report(self._coordinator, self._device)
+        return battery_voltage_mv(report.status if report else None)
+
+    @property
+    @override
+    def native_value(self) -> int | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]
+
+
+@final
+class FindMyStatusCounterSensor(_FindMyBaseSensor):
+    _attr_name = "Status counter"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = False  # diagnostic, opt-in
+    _suffix = "status_counter"
+
+    @override
+    def _compute_value(self) -> int | None:
+        report = latest_report(self._coordinator, self._device)
+        return status_counter(report.status if report else None)
+
+    @property
+    @override
+    def native_value(self) -> int | None:  # pyright: ignore[reportIncompatibleVariableOverride]
+        val = self._cached_value
+        if val is None:
+            val = self._compute_value()
+        return val  # type: ignore[return-value]


### PR DESCRIPTION
Every FindMy device now spawns companion entities alongside its device_tracker, all grouped under one HASS "device":

- sensor.<tag>_latitude (°) - graphable numeric time series
- sensor.<tag>_longitude (°) - graphable numeric time series
- sensor.<tag>_position (lat,lon string) - for notifications / URLs
- sensor.<tag>_battery_level (enum ok/medium/low/critical)
- sensor.<tag>_battery (%, device_class=battery) - drives map icon
- sensor.<tag>_battery_voltage (mV, opt-in) - rough CR2032 estimate
- sensor.<tag>_status_counter (opt-in diagnostic)
- binary_sensor.<tag>_battery_low (device_class=battery)

Rationale: the device_tracker records only home/not_home/zone into HA history; the raw latitude/longitude only live as attributes and can't be charted with the built-in history-graph, ApexCharts, or Statistics platform. Splitting them into numeric sensors makes location trails, motion detection templates and geofencing distance calcs trivial.

Battery data is decoded from bits 6-7 of the Apple Find My status byte that KeyPair / FindMyAccessory advertisements carry. Real AirTags always populate this field; OpenHaystack-style firmwares populate it when built with the battery-reading option enabled.

Also exposes battery_level (%) on the device_tracker itself so HA's map card renders the standard battery icon.