### PR TITLE
Add two automation blueprints for common tag scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 .direnv/
 .ruff_cache/
+
+# Additions for OpenHaystack fork
+.DS_Store

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -1,0 +1,39 @@
+# FindMy - HA Automation Blueprints
+
+Blueprints ship with the integration but are not auto-loaded by Home Assistant.
+Import them manually via URL.
+
+## `tag_zone_change.yaml`
+
+Fires a notification when a tag enters or leaves a zone. Handles the common
+"my bag/bike/laptop just left home" case out of the box.
+
+Import URL:
+```
+https://raw.githubusercontent.com/malmeloo/hass-FindMy/main/blueprints/automation/tag_zone_change.yaml
+```
+
+Steps: Settings → Automations & Scenes → Blueprints → Import Blueprint →
+paste URL. Then Create Automation from the imported blueprint and pick tag,
+zone and notification target.
+
+## `tag_stale.yaml`
+
+Warns when a tag hasn't reported for X hours. Catches dead batteries,
+firmware crashes, or physical removal (thief unpaired the tag / hidden in a
+Faraday cage).
+
+Import URL:
+```
+https://raw.githubusercontent.com/malmeloo/hass-FindMy/main/blueprints/automation/tag_stale.yaml
+```
+
+## Notes on notification targets
+
+For the `notify_service` input:
+- Leave empty for a persistent notification (in the HA UI notification bell)
+- `notify.mobile_app_<devicename>` for the HA Companion App (mobile push)
+- `notify.telegram` if you configured Telegram
+- Any other `notify.*` service you have
+
+To find your service name: Developer Tools → Services → search "notify".

--- a/blueprints/automation/tag_stale.yaml
+++ b/blueprints/automation/tag_stale.yaml
@@ -1,0 +1,95 @@
+blueprint:
+  name: FindMy tag - stale report warning
+  description: >-
+    Warns when a FindMy tag hasn't reported its location for a specified
+    number of hours. Useful to catch dead batteries or firmware crashes early.
+  domain: automation
+  source_url: https://github.com/malmeloo/hass-FindMy/blob/main/blueprints/automation/tag_stale.yaml
+
+  input:
+    tag_entity:
+      name: FindMy tag
+      description: The device_tracker to monitor
+      selector:
+        entity:
+          filter:
+            - integration: findmy
+              domain: device_tracker
+    stale_hours:
+      name: Stale threshold
+      description: Number of hours without a fresh report before triggering
+      default: 24
+      selector:
+        number:
+          min: 1
+          max: 168
+          step: 1
+          unit_of_measurement: h
+          mode: box
+    check_interval_min:
+      name: Check every N minutes
+      description: How often to evaluate the stale condition
+      default: 30
+      selector:
+        number:
+          min: 5
+          max: 240
+          step: 5
+          unit_of_measurement: min
+    notify_service:
+      name: Notification target
+      description: >-
+        Service name like `notify.mobile_app_myphone`. Leave empty for a
+        persistent notification.
+      default: ""
+      selector:
+        text: {}
+
+variables:
+  stale_hours_var: !input stale_hours
+  notify_service_var: !input notify_service
+
+trigger:
+  - platform: time_pattern
+    minutes: !input check_interval_min
+
+condition:
+  - condition: template
+    value_template: >-
+      {% set detected = state_attr(trigger.event_data.entity_id | default('sensor.dummy'), 'detected_at')
+                        or state_attr('{{ trigger.entity_id }}', 'detected_at') %}
+      {# Trigger platform time_pattern has no entity, so we recompute below in action #}
+      true
+
+action:
+  - variables:
+      entity_id_var: !input tag_entity
+      detected_at_raw: "{{ state_attr(entity_id_var, 'detected_at') }}"
+      detected_at_ts: >-
+        {% if detected_at_raw %}
+          {{ as_timestamp(detected_at_raw) }}
+        {% else %}
+          0
+        {% endif %}
+      now_ts: "{{ as_timestamp(now()) }}"
+      age_h: "{{ ((now_ts - (detected_at_ts | float(0))) / 3600) | round(1) }}"
+      tag_name: "{{ state_attr(entity_id_var, 'friendly_name') or entity_id_var }}"
+      message: >-
+        {{ tag_name }} hasn't reported for {{ age_h }} h
+        (threshold: {{ stale_hours_var }} h).
+  - condition: template
+    value_template: >-
+      {{ detected_at_ts | float(0) > 0
+         and (now_ts - detected_at_ts | float(0)) > stale_hours_var * 3600 }}
+  - choose:
+      - conditions: "{{ notify_service_var | length > 0 }}"
+        sequence:
+          - service: "{{ notify_service_var }}"
+            data:
+              title: "FindMy: stale tag"
+              message: "{{ message }}"
+    default:
+      - service: persistent_notification.create
+        data:
+          title: "FindMy: stale tag"
+          message: "{{ message }}"

--- a/blueprints/automation/tag_zone_change.yaml
+++ b/blueprints/automation/tag_zone_change.yaml
@@ -1,0 +1,87 @@
+blueprint:
+  name: FindMy tag - zone enter/leave notification
+  description: >-
+    Fires a notification when a FindMy tag enters or leaves a zone.
+    Works with any device_tracker entity, but pre-selects those provided
+    by the FindMy integration.
+  domain: automation
+  source_url: https://github.com/malmeloo/hass-FindMy/blob/main/blueprints/automation/tag_zone_change.yaml
+
+  input:
+    tag_entity:
+      name: FindMy tag
+      description: The device_tracker to watch
+      selector:
+        entity:
+          filter:
+            - integration: findmy
+              domain: device_tracker
+    zone_entity:
+      name: Zone
+      description: Which zone to watch
+      selector:
+        entity:
+          filter:
+            - domain: zone
+    on_enter:
+      name: Trigger on ENTER
+      description: Notify when the tag enters the zone
+      default: true
+      selector:
+        boolean: {}
+    on_leave:
+      name: Trigger on LEAVE
+      description: Notify when the tag leaves the zone
+      default: true
+      selector:
+        boolean: {}
+    notify_service:
+      name: Notification target
+      description: >-
+        Full service name including domain, e.g. `notify.mobile_app_myphone`
+        or `notify.telegram`. Leave empty to only fire a persistent-notification.
+      default: ""
+      selector:
+        text: {}
+
+variables:
+  notify_service_var: !input notify_service
+  on_enter_var: !input on_enter
+  on_leave_var: !input on_leave
+
+trigger:
+  - platform: zone
+    entity_id: !input tag_entity
+    zone: !input zone_entity
+    event: enter
+    id: entered
+  - platform: zone
+    entity_id: !input tag_entity
+    zone: !input zone_entity
+    event: leave
+    id: left
+
+condition:
+  - condition: template
+    value_template: >-
+      {{ (trigger.id == 'entered' and on_enter_var)
+         or (trigger.id == 'left' and on_leave_var) }}
+
+action:
+  - variables:
+      tag_name: "{{ state_attr(trigger.entity_id, 'friendly_name') or trigger.entity_id }}"
+      zone_name: "{{ state_attr(trigger.zone.entity_id, 'friendly_name') or trigger.zone.entity_id }}"
+      verb: "{{ 'entered' if trigger.id == 'entered' else 'left' }}"
+      message: "{{ tag_name }} has {{ verb }} zone {{ zone_name }}"
+  - choose:
+      - conditions: "{{ notify_service_var | length > 0 }}"
+        sequence:
+          - service: "{{ notify_service_var }}"
+            data:
+              title: FindMy
+              message: "{{ message }}"
+    default:
+      - service: persistent_notification.create
+        data:
+          title: FindMy
+          message: "{{ message }}"


### PR DESCRIPTION
- tag_zone_change.yaml: notify when a tag enters or leaves a zone
- tag_stale.yaml: warn when a tag hasn't reported for N hours

Both are opt-in (users import via URL from the repo blueprints folder), work with any FindMy device_tracker (static/rolling/etc), and support a configurable notify service or fall back to a persistent notification.

Feel free to reject if you prefer blueprints to live in a separate repo - happy to move them.