### PR TITLE
Prompt for re-authentication when the Apple session expires

### DIFF
--- a/custom_components/findmy/config_flow.py
+++ b/custom_components/findmy/config_flow.py
@@ -160,6 +160,9 @@ class InitialSetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._error: Exception | None = None
         self._2fa_methods: list[AsyncSecondFactorMethod] = []
 
+        # Set while re-authenticating an existing entry (see async_step_reauth).
+        self._reauth_entry: config_entries.ConfigEntry | None = None
+
     @override
     async def async_step_user(
         self,
@@ -365,10 +368,92 @@ class InitialSetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             account_data=self._account.to_json(),
         )
 
+        if self._reauth_entry is not None:
+            # Re-authentication: refresh the stored session on the existing
+            # entry rather than creating a duplicate account entry.
+            return self.async_update_reload_and_abort(
+                self._reauth_entry,
+                data=data,
+            )
+
         return self.async_create_entry(
             title=f"Account: {self._account.account_name}",
             data=data,
         )
+
+    ###########################
+    ### Re-authentication   ###
+    ###########################
+
+    async def async_step_reauth(
+        self,
+        entry_data: dict[str, Any],
+    ) -> config_entries.ConfigFlowResult:
+        """Start re-authentication for an account whose session expired."""
+        _LOGGER.debug("%s Step: reauth", self.__class__.__name__)
+
+        entry_id = self.context.get("entry_id")
+        if entry_id is not None:
+            self._reauth_entry = self.hass.config_entries.async_get_entry(entry_id)
+
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        info: LoginFlowInput | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Log the account in again, then reuse the normal 2FA steps."""
+        _LOGGER.debug(
+            "%s Step: reauth_confirm - %s",
+            self.__class__.__name__,
+            {**(info or {}), "password": "**REDACTED**"},
+        )
+
+        entry = self._reauth_entry
+        # The unique_id is the account email, so the address can be pre-filled
+        # and the user only has to supply the password and 2FA code.
+        suggested = {"email": (entry.unique_id or "") if entry else ""}
+
+        if info is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=self.add_suggested_values_to_schema(
+                    DATA_SCHEMA_ACC_LOGIN,
+                    suggested,
+                ),
+                description_placeholders={"account": suggested["email"]},
+            )
+
+        anisette_url = info.get("advanced_options", {}).get("anisette_url") or None
+        _LOGGER.info("Re-authenticating %s (anisette: %s)", info["email"], anisette_url or "<integrated>")
+
+        if anisette_url is None:
+            anisette = LocalAnisetteProvider()
+        else:
+            anisette = RemoteAnisetteProvider(anisette_url)
+        self._account = AsyncAppleAccount(anisette=anisette)
+
+        try:
+            await self._account.login(info["email"], info["password"])
+        except InvalidCredentialsError:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=self.add_suggested_values_to_schema(
+                    DATA_SCHEMA_ACC_LOGIN,
+                    suggested,
+                ),
+                errors={"base": "invalid_auth"},
+                description_placeholders={"account": suggested["email"]},
+            )
+        except UnhandledProtocolError:
+            _LOGGER.exception("Unhandled protocol exception during re-authentication")
+            return self.async_abort(reason="protocol_error")
+
+        _LOGGER.debug("State after re-login: %s", self._account.login_state)
+
+        if self._account.login_state == LoginState.REQUIRE_2FA:
+            return await self.async_step_acc_2fa_prompt()
+        return await self.async_step_acc_done()
 
     #########################
     ### Device Setup Flow ###

--- a/custom_components/findmy/config_flow.py
+++ b/custom_components/findmy/config_flow.py
@@ -425,7 +425,9 @@ class InitialSetupConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         anisette_url = info.get("advanced_options", {}).get("anisette_url") or None
-        _LOGGER.info("Re-authenticating %s (anisette: %s)", info["email"], anisette_url or "<integrated>")
+        _LOGGER.info(
+            "Re-authenticating %s (anisette: %s)", info["email"], anisette_url or "<integrated>"
+        )
 
         if anisette_url is None:
             anisette = LocalAnisetteProvider()

--- a/custom_components/findmy/coordinator.py
+++ b/custom_components/findmy/coordinator.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, final, override
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from findmy import FindMyAccessory, KeyPair, LocationReport, UnauthorizedError
+from findmy import (
+    FindMyAccessory,
+    InvalidStateError,
+    KeyPair,
+    LocationReport,
+    UnauthorizedError,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -79,6 +85,16 @@ class FindMyCoordinator(DataUpdateCoordinator[FindMyLocationData]):
             device_reports = await account.fetch_location(devices)
         except UnauthorizedError as err:
             _LOGGER.exception("Unauthorized... :c")
+            raise ConfigEntryAuthFailed from err
+        except InvalidStateError as err:
+            # Apple invalidates sessions periodically; the account then sits in
+            # REQUIRE_2FA and every fetch raises InvalidStateError. Without this
+            # the entry stays "loaded", entities silently go unavailable and the
+            # user is never prompted to log in again.
+            _LOGGER.warning(
+                "Account is no longer logged in (state: %s); re-authentication required",
+                getattr(account, "login_state", "unknown"),
+            )
             raise ConfigEntryAuthFailed from err
 
         data: FindMyLocationData = (self.data or {}).copy()

--- a/custom_components/findmy/translations/en.json
+++ b/custom_components/findmy/translations/en.json
@@ -56,6 +56,22 @@
           "name": "Name",
           "file": "Device keys"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Apple Account",
+        "description": "The session for {account} has expired and Apple requires signing in again. Your saved devices are kept.",
+        "data": {
+          "email": "E-mail address",
+          "password": "Password"
+        },
+        "sections": {
+          "advanced_options": {
+            "name": "Advanced options",
+            "data": {
+              "anisette_url": "Remote Anisette URL (optional)"
+            }
+          }
+        }
       }
     },
     "error": {
@@ -67,7 +83,8 @@
     },
     "abort": {
       "protocol_error": "A protocol exception occurred. Please report this error and try again later.",
-      "unknown_error": "An unexpected error occurred. Please try again later."
+      "unknown_error": "An unexpected error occurred. Please try again later.",
+      "reauth_successful": "Re-authentication was successful"
     }
   },
   "selector": {


### PR DESCRIPTION
Fixes #50.

## Problem

Apple invalidates account sessions periodically. The account then sits in `LoginState.REQUIRE_2FA` and every location fetch raises `findmy.errors.InvalidStateError`:

```
Invalid login state! Currently: LoginState.REQUIRE_2FA but should be one of: (LoginState.LOGGED_IN,)
```

`coordinator.py` maps only `UnauthorizedError` onto `ConfigEntryAuthFailed`, so this surfaces as a generic update failure instead. The config entry stays `loaded`, every tracker goes `unavailable`, and no re-authentication notification is raised — nothing indicates a login is needed. In my case the integration sat broken for eight days before I noticed, and an automation built on those trackers was silently disabled the whole time.

## Changes

**`coordinator.py`** — treat `InvalidStateError` as an auth failure so Home Assistant raises the re-authentication prompt. Logged at `warning` with the current login state rather than `exception`, since an expired session is expected rather than a crash.

**`config_flow.py`** — add `async_step_reauth` / `async_step_reauth_confirm`. This is required for the above to be actionable: HA responds to `ConfigEntryAuthFailed` by starting a reauth flow, which cannot complete without these steps. The implementation:

- reuses the existing login and 2FA handling, so trusted-device and SMS flows work unchanged;
- pre-fills the e-mail from the entry's `unique_id`, leaving only the password and 2FA code to enter;
- updates the existing entry via `async_update_reload_and_abort` instead of creating a duplicate account entry;
- leaves `Device (Rolling):` entries untouched, so trackers resume as soon as the session is valid.

**`translations/en.json`** — strings for the new step, reusing the existing login field labels, plus `reauth_successful`.

## Testing

Verified against the failing setup (HA 2026.8.1, FindMy.py 0.10.1, self-hosted anisette):

- both modified modules compile; `en.json` parses;
- every `step_id` referenced in the flow resolves to a translation, except one pre-existing mismatch noted below;
- the manual equivalent of this flow — re-entering credentials and a 2FA code against the same account, keeping the device entries — restores all four trackers to reporting, which is the path `reauth_confirm` automates.

I could not exercise the automatic prompt end to end without waiting for Apple to invalidate the session again, so a review of the reauth wiring specifically would be welcome.

## Out of scope

`config_flow.py:333` uses `step_id="2fa_submit"` where the surrounding code and translations use `acc_2fa_submit`, so that error path renders untranslated keys. Pre-existing and unrelated; left alone to keep this focused.
