### PR TITLE
Add local Bluetooth tracking for rolling-key accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ By default, the integration will only use your account to fetch for updates once
 reduce the risk of being banned by Apple. If you want to increase the tracker update frequency, it is possible
 to add additional accounts. These accounts will divide the available time; 2 accounts will generate updates every
 7.5 minutes, 3 will update every 5 minutes, etc.
+
+## Local Bluetooth tracking
+
+Rolling-key accessories such as official AirTags can also be detected by Home Assistant Bluetooth adapters and
+ESPHome Bluetooth proxies. Local detections update independently of the 15-minute Find My network polling interval.
+
+The device tracker exposes the confirmed current address in `mac_address` and adds these attributes:
+
+- `local_detected_at`
+- `local_rssi`
+- `local_source`
+- `local_state` (`nearby` or `separated`)
+- `local_battery` (`Full`, `Medium`, `Low`, or `Very Low`)
+- `local_key_candidates`
+
+All key matching happens inside Home Assistant. Local presence tracking therefore continues without an internet
+connection after the rolling-key accessory has been imported, although remote Find My network locations still
+require an Apple account and internet access.

--- a/custom_components/findmy/device_tracker.py
+++ b/custom_components/findmy/device_tracker.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+from datetime import UTC, datetime, timedelta
 from functools import cached_property
+from time import monotonic
 from typing import TYPE_CHECKING, final, override
 
+from homeassistant.components import bluetooth
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -11,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from findmy import FindMyAccessory, KeyPair
@@ -18,11 +23,17 @@ from findmy import FindMyAccessory, KeyPair
 from .config_flow import DeviceEntryData
 from .const import DOMAIN
 from .coordinator import FindMyCoordinator, FindMyDevice
+from .local_bluetooth import (
+    APPLE_COMPANY_ID,
+    CandidateKeyLookup,
+    LocalObservation,
+    build_candidate_key_lookup_from_json,
+    match_local_advertisement,
+)
 from .storage import RuntimeStorage
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from datetime import datetime
 
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -33,6 +44,11 @@ if TYPE_CHECKING:
     from .config_flow import DeviceEntryData
 
 _LOGGER = logging.getLogger(__name__)
+
+_LOCAL_KEY_REFRESH_INTERVAL = timedelta(minutes=15)
+_LOCAL_STATE_UPDATE_DELAY = 60
+_LOCAL_ALIGNMENT_UPDATE_DELAY = 60
+_LOCAL_ALIGNMENT_SAVE_DELAY = 15 * 60
 
 
 async def async_setup_entry(
@@ -71,6 +87,16 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
         self._entry_id: str = entry_id
 
         self._last_location: LocationReport | None = None
+        self._local_observation: LocalObservation | None = None
+        self._local_source: str | None = None
+        self._local_candidates: CandidateKeyLookup = {}
+        self._local_candidate_count = 0
+        self._local_refresh_lock = asyncio.Lock()
+        self._local_refresh_tasks: set[asyncio.Task[None]] = set()
+        self._local_active = False
+        self._last_local_state_update = 0.0
+        self._last_alignment_update = 0.0
+        self._last_alignment_save = 0.0
 
         # Define entity id
         # Set here instead of in a property because it needs a setter, so this is more convenient.
@@ -79,6 +105,144 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
             self.given_name,
             hass=self._coordinator.hass,
         )
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Start local Bluetooth matching for rolling-key accessories."""
+        await super().async_added_to_hass()
+
+        if not isinstance(self._device, FindMyAccessory):
+            return
+
+        self._local_active = True
+        self.async_on_remove(
+            bluetooth.async_register_callback(
+                self.hass,
+                self._async_track_service_info,
+                bluetooth.BluetoothCallbackMatcher(
+                    connectable=False,
+                    manufacturer_id=APPLE_COMPANY_ID,
+                ),
+                bluetooth.BluetoothScanningMode.PASSIVE,
+            ),
+        )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._async_refresh_local_candidates,
+                _LOCAL_KEY_REFRESH_INTERVAL,
+            ),
+        )
+        self.async_on_remove(self._cancel_local_refresh_tasks)
+
+        self._schedule_local_candidate_refresh("initial")
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Stop publishing results while background work is winding down."""
+        self._local_active = False
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _cancel_local_refresh_tasks(self) -> None:
+        """Cancel outstanding candidate generation tasks."""
+        for task in self._local_refresh_tasks:
+            _ = task.cancel()
+        self._local_refresh_tasks.clear()
+
+    @callback
+    def _schedule_local_candidate_refresh(self, reason: str) -> None:
+        """Schedule candidate generation and retain the task until completion."""
+        task = self.hass.async_create_task(
+            self._async_refresh_local_candidates(),
+            f"findmy local key cache ({reason}): {self.unique_id}",
+        )
+        self._local_refresh_tasks.add(task)
+        task.add_done_callback(self._local_refresh_tasks.discard)
+
+    async def _async_refresh_local_candidates(self, _now: datetime | None = None) -> None:
+        """Generate rolling-key candidates outside Home Assistant's event loop."""
+        if not isinstance(self._device, FindMyAccessory):
+            return
+
+        async with self._local_refresh_lock:
+            observed_at = datetime.now(tz=UTC)
+            accessory_data = self._device.to_json()
+            candidates = await self.hass.async_add_executor_job(
+                build_candidate_key_lookup_from_json,
+                accessory_data,
+                observed_at,
+            )
+
+            if not self._local_active:
+                return
+
+            self._local_candidates = candidates
+            self._local_candidate_count = sum(len(keys) for keys in candidates.values())
+            _LOGGER.debug(
+                "Prepared %i local rolling-key candidates for %s",
+                self._local_candidate_count,
+                self.given_name,
+            )
+            self.async_write_ha_state()
+
+    @callback
+    def _async_track_service_info(
+        self,
+        service_info: bluetooth.BluetoothServiceInfoBleak,
+        _change: bluetooth.BluetoothChange,
+    ) -> None:
+        """Match an Apple advertisement against the pre-generated key cache."""
+        if not isinstance(self._device, FindMyAccessory):
+            return
+
+        apple_data = service_info.manufacturer_data.get(APPLE_COMPANY_ID)
+        if apple_data is None or not self._local_candidates:
+            return
+
+        observation = match_local_advertisement(
+            service_info.address,
+            apple_data,
+            datetime.now(tz=UTC),
+            service_info.rssi,
+            self._local_candidates,
+        )
+        if observation is None:
+            return
+
+        previous = self._local_observation
+        self._local_observation = observation
+        self._local_source = service_info.source
+
+        now_mono = monotonic()
+        current_index = self._device._alignment_index  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+        index_changed = observation.can_align and observation.key_index != current_index
+        if observation.can_align and (
+            index_changed or now_mono - self._last_alignment_update >= _LOCAL_ALIGNMENT_UPDATE_DELAY
+        ):
+            self._device.update_alignment(observation.detected_at, observation.key_index)
+            self._last_alignment_update = now_mono
+
+        if observation.can_align and (
+            index_changed or now_mono - self._last_alignment_save >= _LOCAL_ALIGNMENT_SAVE_DELAY
+        ):
+            self._update_entry()
+            self._last_alignment_save = now_mono
+
+        identity_changed = (
+            previous is None
+            or previous.mac_address != observation.mac_address
+            or previous.state != observation.state
+        )
+        if (
+            identity_changed
+            or now_mono - self._last_local_state_update >= _LOCAL_STATE_UPDATE_DELAY
+        ):
+            self._last_local_state_update = now_mono
+            self.async_write_ha_state()
+
+        if index_changed:
+            self._schedule_local_candidate_refresh("realignment")
 
     @property
     def findmy_device(self) -> FindMyDevice:
@@ -137,6 +301,8 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
     def mac_address(self) -> str | None:
         if isinstance(self._device, KeyPair):
             return self._device.mac_address
+        if self._local_observation is not None:
+            return self._local_observation.mac_address
         return None
 
     @cached_property
@@ -163,6 +329,22 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
             # TODO(malmeloo): make properties public in FindMy.py  # noqa: FIX002, TD003
             attrs["alignment_index"] = self._device._alignment_index  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
             attrs["alignment_date"] = self._device._alignment_date  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+            attrs["local_key_candidates"] = self._local_candidate_count
+            attrs["local_detected_at"] = (
+                self._local_observation.detected_at if self._local_observation is not None else None
+            )
+            attrs["local_rssi"] = (
+                self._local_observation.rssi if self._local_observation is not None else None
+            )
+            attrs["local_source"] = self._local_source
+            attrs["local_state"] = (
+                self._local_observation.state if self._local_observation is not None else None
+            )
+            attrs["local_battery"] = (
+                self._local_observation.battery_level
+                if self._local_observation is not None
+                else None
+            )
 
         return attrs
 

--- a/custom_components/findmy/device_tracker.py
+++ b/custom_components/findmy/device_tracker.py
@@ -115,17 +115,20 @@ class FindMyDeviceTracker(  # pyright: ignore [reportUninitializedInstanceVariab
             return
 
         self._local_active = True
-        self.async_on_remove(
-            bluetooth.async_register_callback(
-                self.hass,
-                self._async_track_service_info,
-                bluetooth.BluetoothCallbackMatcher(
-                    connectable=False,
-                    manufacturer_id=APPLE_COMPANY_ID,
+        # Nearby/separated advertisements and Bluetooth proxies do not always
+        # classify the AirTag's connectability consistently, so listen for both.
+        for connectable in (False, True):
+            self.async_on_remove(
+                bluetooth.async_register_callback(
+                    self.hass,
+                    self._async_track_service_info,
+                    bluetooth.BluetoothCallbackMatcher(
+                        connectable=connectable,
+                        manufacturer_id=APPLE_COMPANY_ID,
+                    ),
+                    bluetooth.BluetoothScanningMode.PASSIVE,
                 ),
-                bluetooth.BluetoothScanningMode.PASSIVE,
-            ),
-        )
+            )
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,

--- a/custom_components/findmy/local_bluetooth.py
+++ b/custom_components/findmy/local_bluetooth.py
@@ -1,0 +1,151 @@
+"""Efficient matching of local Find My Bluetooth advertisements."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from findmy import (
+    FindMyAccessory,
+    KeyPairType,
+    NearbyOfflineFindingDevice,
+    OfflineFindingDevice,
+    SeparatedOfflineFindingDevice,
+)
+
+if TYPE_CHECKING:
+    from findmy import FindMyAccessoryMapping
+
+APPLE_COMPANY_ID = 0x004C
+KEY_WINDOW = timedelta(hours=12)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateKey:
+    """A generated rolling key and its accessory index."""
+
+    index: int
+    adv_key: bytes
+    can_align: bool
+
+
+type CandidateKeyLookup = Mapping[bytes, tuple[CandidateKey, ...]]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalObservation:
+    """A verified local observation of a rolling-key accessory."""
+
+    mac_address: str
+    detected_at: datetime
+    rssi: int | None
+    state: str
+    battery_level: str
+    status: int
+    key_index: int
+    can_align: bool
+
+
+def build_candidate_key_lookup(
+    accessory: FindMyAccessory,
+    observed_at: datetime,
+) -> dict[bytes, tuple[CandidateKey, ...]]:
+    """Build a lookup keyed by the six public-key bytes visible nearby."""
+    candidates: defaultdict[bytes, list[CandidateKey]] = defaultdict(list)
+
+    for index, key in accessory.keys_between(
+        observed_at - KEY_WINDOW,
+        observed_at + KEY_WINDOW,
+    ):
+        adv_key = key.adv_key_bytes
+        candidates[adv_key[:6]].append(
+            CandidateKey(
+                index=index,
+                adv_key=adv_key,
+                can_align=key.key_type == KeyPairType.PRIMARY,
+            ),
+        )
+
+    return {partial_key: tuple(keys) for partial_key, keys in candidates.items()}
+
+
+def build_candidate_key_lookup_from_json(
+    accessory_data: FindMyAccessoryMapping,
+    observed_at: datetime,
+) -> dict[bytes, tuple[CandidateKey, ...]]:
+    """Build candidates from a snapshot to avoid mutating the live key generators."""
+    return build_candidate_key_lookup(FindMyAccessory.from_json(accessory_data), observed_at)
+
+
+def extract_offline_finding_payload(apple_data: bytes) -> bytes | None:
+    """Extract one complete nearby or separated Offline Finding section."""
+    for offset in range(max(0, len(apple_data) - 1)):
+        if apple_data[offset] != OfflineFindingDevice.OF_TYPE:
+            continue
+
+        payload_length = apple_data[offset + 1]
+        if payload_length not in (
+            NearbyOfflineFindingDevice.OF_PAYLOAD_LEN,
+            SeparatedOfflineFindingDevice.OF_PAYLOAD_LEN,
+        ):
+            continue
+
+        section_end = offset + OfflineFindingDevice.OF_HEADER_SIZE + payload_length
+        if section_end <= len(apple_data):
+            return apple_data[offset:section_end]
+
+    return None
+
+
+def match_local_advertisement(
+    address: str,
+    apple_data: bytes,
+    detected_at: datetime,
+    rssi: int | None,
+    candidates: CandidateKeyLookup,
+) -> LocalObservation | None:
+    """Return an observation only when an advertisement matches a candidate key."""
+    payload = extract_offline_finding_payload(apple_data)
+    if payload is None:
+        return None
+
+    try:
+        device = OfflineFindingDevice.from_ble_payload(
+            address,
+            payload,
+            detected_at,
+            rssi,
+        )
+    except (IndexError, ValueError):
+        return None
+
+    if isinstance(device, NearbyOfflineFindingDevice):
+        partial_key = device.partial_adv_key
+        full_key = None
+        state = "nearby"
+    elif isinstance(device, SeparatedOfflineFindingDevice):
+        partial_key = device.adv_key_bytes[:6]
+        full_key = device.adv_key_bytes
+        state = "separated"
+    else:
+        return None
+
+    for candidate in candidates.get(partial_key, ()):
+        if full_key is not None and candidate.adv_key != full_key:
+            continue
+
+        return LocalObservation(
+            mac_address=device.mac_address,
+            detected_at=device.detected_at,
+            rssi=device.rssi,
+            state=state,
+            battery_level=device.battery_level,
+            status=device.status,
+            key_index=candidate.index,
+            can_align=candidate.can_align,
+        )
+
+    return None

--- a/custom_components/findmy/manifest.json
+++ b/custom_components/findmy/manifest.json
@@ -5,6 +5,7 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "config_flow": true,
+  "dependencies": ["bluetooth"],
   "documentation": "https://github.com/malmeloo/hass-findmy",
   "issue_tracker": "https://github.com/malmeloo/hass-findmy/issues",
   "requirements": ["FindMy==0.10.1"]


### PR DESCRIPTION
## Summary

- Precompute a bounded rolling-key lookup outside Home Assistant's event loop.
- Match nearby and separated Apple Offline Finding advertisements received by HA Bluetooth adapters and ESPHome Bluetooth proxies.
- Expose the confirmed rolling MAC, RSSI, detection time, proxy source, battery level, nearby/separated state, and candidate count on the existing device tracker.
- Keep rolling-key alignment current and persist it with rate limits to avoid excessive config-entry writes.
- Allow local presence tracking to continue offline after an accessory is imported; remote Find My locations still use the existing account-based polling.

Closes #52.

Companion Bermuda support: agittins/bermuda#816.

## Implementation notes

The live Bluetooth callback only performs dictionary lookup and payload verification. Rolling keys for a +/-12-hour window are generated from a cloned accessory snapshot in Home Assistant's executor, avoiding generator mutation and event-loop stalls. Separated advertisements require a full 28-byte key match; nearby advertisements use the six key bytes available in that packet format.

The callback uses passive scanning and subscribes to both connectable classifications because nearby/separated advertisements and Bluetooth proxies do not always classify an AirTag consistently. It also supports Apple manufacturer data that contains additional trailing sections.

## Testing

- Manually tested on Home Assistant 2026.8.2 with a real AirTag and ESPHome Bluetooth proxies.
- Confirmed 99 rolling-key candidates generated in approximately 0.07 seconds on the live HA host.
- Confirmed live MAC rotation, RSSI, proxy source, battery state, nearby/separated state, and timestamp attributes.
- Confirmed the device congeals with Bermuda and produces stable area, distance, and presence entities.
- `ruff check custom_components/findmy`
- `ruff format --check custom_components/findmy`
- `python -m compileall -q custom_components/findmy`
- Synthetic nearby, separated, trailing-section, non-match, and malformed-payload assertions.

`basedpyright` retains the four existing `TrackerEntity`/override diagnostics caused by checking this branch against Home Assistant 2026.8.2; this change introduces no additional diagnostics.

## AI disclosure

This implementation was developed with assistance from OpenAI Codex, then manually reviewed and tested on Home Assistant 2026.8.2 with a real AirTag and ESPHome Bluetooth proxies.
